### PR TITLE
fix: change sharp version from 0.33.2 to 0.32.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"html-minifier-terser": "7.2.0",
 		"kleur": "4.1.5",
 		"lightningcss": "1.24.0",
-		"sharp": "0.33.2",
+		"sharp": "0.32.6",
 		"svgo": "3.2.0",
 		"terser": "5.29.1"
 	},


### PR DESCRIPTION
![image](https://github.com/astro-community/AstroCompress/assets/93441520/65319a56-1216-4d89-99db-e6ddd688f5d6)
 in other word, when using vite-pwa gets conflict ( a lot of )  because astro and vite uses sharp@0.32.6