### PR TITLE
docs: Add example of config override

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,26 @@ You can override any of the default options from the configurations of:
 -   [svgo](https://github.com/svg/svgo#configuration)
 -   [terser](https://github.com/terser/terser#minify-options-structure)
 
+**`astro.config.ts`**
+
+```ts
+export default {
+	integrations: [
+		(await import("@playform/compress")).default({
+			CSS: false,
+			HTML: {
+				'html-minifier-terser': {
+					removeAttributeQuotes: false,
+				},
+			},
+			Image: false,
+			JavaScript: false,
+			SVG: false,
+		}),
+	],
+};
+```
+
 or disable them entirely:
 
 **`astro.config.ts`**


### PR DESCRIPTION
I find it important to showcase how a plugin's configuration can be overriden as you need to use the plugin's name as a key.