### PR TITLE
move astro back to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
 		"@playform/pipe": "0.1.5",
 		"@types/csso": "5.0.4",
 		"@types/html-minifier-terser": "7.0.2",
-		"astro": "*",
 		"commander": "14.0.3",
 		"csso": "5.0.5",
 		"deepmerge-ts": "7.1.5",
@@ -60,6 +59,9 @@
 		"@playform/build": "0.3.1",
 		"browserslist": "4.28.2",
 		"lightningcss": "1.32.0"
+	},
+	"peerDependencies": {
+		"astro": "*"
 	},
 	"publishConfig": {
 		"access": "public",


### PR DESCRIPTION
It used to be like this, but then was reverted in https://github.com/PlayForm/Compress/commit/c1efeaa5fdaa6e6022d79306a69f0cc664cc3b44 with no comment or explanation.

It's been causing astro and vite to have two variants in my pnpm project for a while now, and I finally decided to actually get to the bottom of it.